### PR TITLE
Catch unfixable jscs errors in gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,5 @@
 var gulp = require( "gulp" );
+var gutil = require( "gulp-util" );
 var bg = require( "biggulp" )( gulp );
 var jscs = require( "gulp-jscs" );
 var gulpChanged = require( "gulp-changed" );
@@ -40,6 +41,10 @@ gulp.task( "format", [ "jshint" ], function() {
 			configPath: ".jscsrc",
 			fix: true
 		} ) )
+		.on( "error", function( error ) {
+			gutil.log( gutil.colors.red( error.message ) );
+			this.end();
+		} )
 		.pipe( gulpChanged( ".", { hasChanged: gulpChanged.compareSha1Digest } ) )
 		.pipe( gulp.dest( "." ) );
 } );

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "gulp-changed": "^1.2.1",
     "gulp-jscs": "^1.6.0",
     "gulp-jshint": "^1.11.0",
+    "gulp-util": "~3.0.5",
     "jshint": "^2.7.0",
     "jshint-stylish": "^2.0.0",
     "processhost": "^0.2.1",


### PR DESCRIPTION
Properly handle errors when jscs is unable to fix a formatting issue.