### PR TITLE
Clear error state after a delay

### DIFF
--- a/spec/behavior/hilo.spec.js
+++ b/spec/behavior/hilo.spec.js
@@ -29,7 +29,7 @@ function getDataStub( nextHiVal ) {
 	};
 }
 
-describe( "node-hilo - unit tests", function() {
+describe.only( "node-hilo - unit tests", function() {
 	describe( "generated unit tests", function() {
 		var hivals = [ "0", "1", "10", "100", "1000", "10000", "100000", "1000000", "10000000", "100000000", "1000000000" ].map( function( x ) {
 			return bigInt( x, 10 );
@@ -110,42 +110,6 @@ describe( "node-hilo - unit tests", function() {
 				return hilo.nextId().should.be.rejectedWith( /An unknown error has occurred/ );
 			} );
 		} );
-
-		describe( "with resetDelay of 100ms", function() {
-			var dbCalls = 0;
-			var hilo;
-
-			before( function() {
-				var stubiate = {
-					executeTransaction: function() {
-						// First call fails
-						return dbCalls++ ? getDataStub( 100000 ) : when.reject();
-					},
-					fromFile: function() {}
-				};
-				hilo = getHiloInstance( stubiate, { hilo: { maxLo: 10, retryDelay: 100 } } );
-			} );
-
-			it( "should fail on first call", function() {
-				hilo.nextId().should.be.rejectedWith( /An unknown error has occurred/ );
-				dbCalls.should.equal( 1 );
-			} );
-
-			it( "should fail immediately if called again in less 100ms", function() {
-				hilo.nextId().should.be.rejectedWith( /An unknown error has occurred/ );
-				dbCalls.should.equal( 1 );
-			} );
-
-			it( "should succeed if called after 100ms", function( done ) {
-				setTimeout( function() {
-					hilo.nextId().then( function( id ) {
-						dbCalls.should.equal( 2 );
-						id.should.equal( "1100000" );
-						done();
-					}, done );
-				}, 101 );
-			} );
-		} );
 	} );
 
 	describe( "when the DB doesn't return a valid hival", function() {
@@ -178,6 +142,112 @@ describe( "node-hilo - unit tests", function() {
 		it( "should reject if an null is returned", function() {
 			dbHival = null;
 			return hilo.nextId().should.be.rejectedWith( /Invalid hival returned from database/ );
+		} );
+	} );
+
+	describe( "when a DB failure is followed by success", function() {
+		var succeed = false;
+		var dbCalls = 0;
+		var hilo;
+
+		before( function() {
+			var stubiate = {
+				executeTransaction: function() {
+					dbCalls++;
+					return succeed ? getDataStub( 100000 ) : when.reject();
+				},
+				fromFile: function() {}
+			};
+			hilo = getHiloInstance( stubiate, { hilo: { maxLo: 10 } } );
+		} );
+
+		it( "should double the retryDelay on failure", function() {
+			succeed = false;
+			return hilo.nextId().should.be.rejectedWith( /An unknown error has occurred/ ).then( function() {
+				hilo.retryDelay.should.equal( 2 );
+				dbCalls.should.equal( 1 );
+			} );
+		} );
+
+		it( "should reset the retryDelay on success", function( done ) {
+			succeed = true;
+			setTimeout( function() {
+				hilo.nextId().then( function( id ) {
+					hilo.retryDelay.should.equal( 1 );
+					dbCalls.should.equal( 2 );
+					id.should.equal( "1100000" );
+					done();
+				}, done );
+			}, hilo.retryDelay + 1 );
+		} );
+	} );
+
+	describe( "with DB consistently failing", function() {
+		var succeed = false;
+		var dbCalls = 0;
+		var hilo;
+
+		before( function() {
+			var stubiate = {
+				executeTransaction: function() {
+					dbCalls++;
+					return succeed ? getDataStub( 100000 ) : when.reject();
+				},
+				fromFile: function() {}
+			};
+			hilo = getHiloInstance( stubiate, { hilo: { maxLo: 10, maxRetryDelay: 100 } } );
+		} );
+
+		it( "should double the retryDelay on failure", function( done ) {
+			succeed = false;
+			var call = 0;
+			function tryNextId() {
+				call++;
+				hilo.nextId().should.be.rejectedWith( /An unknown error has occurred/ ).then( function() {
+					hilo.retryDelay.should.equal( Math.pow( 2, call ) );
+					dbCalls.should.equal( call );
+
+					// First 6 failures should take us to a retryDelay of 64ms
+					if ( call < 6 ) {
+						setTimeout( tryNextId, hilo.retryDelay + 1 );
+					} else {
+						done();
+					}
+				}, done );
+			}
+			tryNextId();
+		} );
+
+		it( "should cap retryDelay at maxRetryDelay", function( done ) {
+			succeed = false;
+			setTimeout( function() {
+				hilo.nextId().should.be.rejectedWith( /An unknown error has occurred/ ).then( function() {
+					// 7th call would have bumped us to 128ms without a maxRetryDelay of 100
+					hilo.retryDelay.should.equal( 100 );
+					dbCalls.should.equal( 7 );
+					done();
+				}, done );
+			}, hilo.retryDelay + 1 );
+		} );
+
+		it( "should fail without hitting DB if called before retryDelay expires", function() {
+			succeed = true;
+			return hilo.nextId().should.be.rejectedWith( /An unknown error has occurred/ ).then( function() {
+				hilo.retryDelay.should.equal( 100 );
+				dbCalls.should.equal( 7 );
+			} );
+		} );
+
+		it( "should recover after retryDelay expires", function( done ) {
+			succeed = true;
+			setTimeout( function() {
+				hilo.nextId().then( function( id ) {
+					hilo.retryDelay.should.equal( 1 );
+					dbCalls.should.equal( 8 );
+					id.should.equal( "1100000" );
+					done();
+				}, done );
+			}, hilo.retryDelay + 1 );
 		} );
 	} );
 } );

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ function processHiValResponse( hv ) {
 	this.hival = bigInt( hv.next_hi );
 	this.lo = ( this.hival.equals( 0 ) ) ? 1 : 0;
 	this.hi = this.hival.times( this.maxLo + 1 );
+	this.retryDelay = 1;
 	this.transition( "ready" );
 }
 
@@ -50,6 +51,7 @@ var HiLoFsm = machina.Fsm.extend( {
 				this.timer = setTimeout( function() {
 					this.handle( "clearErrorState" );
 				}.bind( this ), this.retryDelay );
+				this.retryDelay = Math.min( this.retryDelay * 2, this.maxRetryDelay );
 			},
 			clearErrorState: "uninitialized",
 			_onExit: function() {
@@ -86,7 +88,8 @@ module.exports = function( seriate, config ) {
 	var hiloFsm = new HiLoFsm( {
 		initialize: function() {
 			this.maxLo = config.hilo.maxLo;
-			this.retryDelay = config.hilo.retryDelay || 30000;
+			this.maxRetryDelay = config.hilo.maxRetryDelay || 5000;
+			this.retryDelay = 1;
 			this.getNextHival = function() {
 				return seriate.executeTransaction( config.sql, {
 					preparedSql: seriate.fromFile( "./sql/nexthi.sql" )
@@ -106,16 +109,19 @@ module.exports = function( seriate, config ) {
 		}
 	};
 
-	Object.defineProperty(
-		hilo,
-		"hival",
-		{
-			enumerable: true,
-			get: function() {
-				return hiloFsm.hival && hiloFsm.hival.toString();
-			}
+	Object.defineProperty( hilo, "hival", {
+		enumerable: true,
+		get: function() {
+			return hiloFsm.hival && hiloFsm.hival.toString();
 		}
-	);
+	} );
+
+	Object.defineProperty( hilo, "retryDelay", {
+		enumerable: true,
+		get: function() {
+			return hiloFsm.retryDelay;
+		}
+	} );
 
 	return hilo;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,15 @@ var HiLoFsm = machina.Fsm.extend( {
 			}
 		},
 		dbFailure: {
+			_onEnter: function() {
+				this.timer = setTimeout( function() {
+					this.handle( "clearErrorState" );
+				}.bind( this ), this.retryDelay );
+			},
+			clearErrorState: "uninitialized",
+			_onExit: function() {
+				clearTimeout( this.timer );
+			},
 			nextId: function( done ) {
 				done( this.err || new HiloGenerationError( "An unknown error has occurred." ) );
 			}
@@ -77,6 +86,7 @@ module.exports = function( seriate, config ) {
 	var hiloFsm = new HiLoFsm( {
 		initialize: function() {
 			this.maxLo = config.hilo.maxLo;
+			this.retryDelay = config.hilo.retryDelay || 30000;
 			this.getNextHival = function() {
 				return seriate.executeTransaction( config.sql, {
 					preparedSql: seriate.fromFile( "./sql/nexthi.sql" )


### PR DESCRIPTION
The previous version would always return an error if an error occurred once. This is a simple solution that basically resets the state of the FSM following a short delay after an error. 

It is defaulting to a 30 second delay during which an error will be returned without calling the db. Once 30 seconds have elapsed, the state is reset and a call to the db will be allowed again.

To whoever reviews this: let me know if you think we need a more sophisticated solution (error counts, increasing delays, or different handling based on error type).