### PR TITLE
Update tedious to 19.2.0, force update jws to 4.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"dependencies": {
 				"big-integer": "^1.6.52",
 				"machina": "^4.0.2",
-				"tedious": "^19.0.0"
+				"tedious": "^19.2.0"
 			},
 			"devDependencies": {
 				"c8": "^10.1.3",
@@ -301,13 +301,10 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.1.tgz",
-			"integrity": "sha512-+BIznRzyqBf+2wCTxcKE3wDjfGeCoVE61KSHGpkzqrLi8qxqFwBeUFyId2cxkTmm55fzDGnm0+yCxaxygrLUnQ==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+			"integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
 			"dev": true,
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -535,9 +532,9 @@
 			}
 		},
 		"node_modules/@js-joda/core": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.6.2.tgz",
-			"integrity": "sha512-ow4R+7C24xeTjiMTTZ4k6lvxj7MRBqvqLCQjThQff3RjOmIMokMP20LNYVFhGafJtUx/Xo2Qp4qU8eNoTVH0SA=="
+			"version": "5.6.5",
+			"resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.6.5.tgz",
+			"integrity": "sha512-3zwefSMwHpu8iVUW8YYz227sIv6UFqO31p1Bf1ZH/Vom7CmNyUsXjDBlnNzcuhmOL1XfxZ3nvND42kR23XlbcQ=="
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -635,26 +632,20 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "20.12.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.2.tgz",
-			"integrity": "sha512-zQ0NYO87hyN6Xrclcqp7f8ZbXNbRfoGWNcMvHTPQp9UUrwI0mI7XBz+cu7/W6/VClYo2g63B0cjull/srU7LgQ==",
+			"version": "25.0.9",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.9.tgz",
+			"integrity": "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==",
 			"dependencies": {
-				"undici-types": "~5.26.4"
+				"undici-types": "~7.16.0"
 			}
 		},
 		"node_modules/@types/readable-stream": {
-			"version": "4.0.11",
-			"resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.11.tgz",
-			"integrity": "sha512-R3eUMUTTKoIoaz7UpYLxvZCrOmCRPRbAmoDDHKcimTEySltaJhF8hLzj4+EzyDifiX5eK6oDQGSfmNnXjxZzYQ==",
+			"version": "4.0.23",
+			"resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.23.tgz",
+			"integrity": "sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==",
 			"dependencies": {
-				"@types/node": "*",
-				"safe-buffer": "~5.1.1"
+				"@types/node": "*"
 			}
-		},
-		"node_modules/@types/readable-stream/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"node_modules/@ungap/structured-clone": {
 			"version": "1.2.0",
@@ -1015,9 +1006,9 @@
 			}
 		},
 		"node_modules/bl": {
-			"version": "6.0.12",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-6.0.12.tgz",
-			"integrity": "sha512-EnEYHilP93oaOa2MnmNEjAcovPS3JlQZOyzGXi3EyEpPhm9qWvdDp7BmAVEVusGzp8LlwQK56Av+OkDoRjzE0w==",
+			"version": "6.1.6",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-6.1.6.tgz",
+			"integrity": "sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg==",
 			"dependencies": {
 				"@types/readable-stream": "^4.0.0",
 				"buffer": "^6.0.3",
@@ -1026,9 +1017,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -1036,12 +1027,12 @@
 			}
 		},
 		"node_modules/braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
 			"dependencies": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -1449,9 +1440,9 @@
 			}
 		},
 		"node_modules/diff": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-			"integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+			"integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.3.1"
@@ -2087,9 +2078,9 @@
 			}
 		},
 		"node_modules/fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
@@ -2499,14 +2490,18 @@
 			}
 		},
 		"node_modules/iconv-lite": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
 			"dependencies": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/ieee754": {
@@ -3178,9 +3173,9 @@
 			"dev": true
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 			"dev": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -3223,21 +3218,21 @@
 			}
 		},
 		"node_modules/jsonwebtoken/node_modules/jwa": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-			"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+			"integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
 			"dependencies": {
-				"buffer-equal-constant-time": "1.0.1",
+				"buffer-equal-constant-time": "^1.0.1",
 				"ecdsa-sig-formatter": "1.0.11",
 				"safe-buffer": "^5.0.1"
 			}
 		},
 		"node_modules/jsonwebtoken/node_modules/jws": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-			"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+			"integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
 			"dependencies": {
-				"jwa": "^1.4.1",
+				"jwa": "^1.4.2",
 				"safe-buffer": "^5.0.1"
 			}
 		},
@@ -3274,21 +3269,21 @@
 			"dev": true
 		},
 		"node_modules/jwa": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-			"integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
 			"dependencies": {
-				"buffer-equal-constant-time": "1.0.1",
+				"buffer-equal-constant-time": "^1.0.1",
 				"ecdsa-sig-formatter": "1.0.11",
 				"safe-buffer": "^5.0.1"
 			}
 		},
 		"node_modules/jws": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-			"integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
 			"dependencies": {
-				"jwa": "^2.0.0",
+				"jwa": "^2.0.1",
 				"safe-buffer": "^5.0.1"
 			}
 		},
@@ -3569,9 +3564,9 @@
 			}
 		},
 		"node_modules/mocha/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
 			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0"
@@ -3590,9 +3585,9 @@
 			}
 		},
 		"node_modules/mocha/node_modules/glob": {
-			"version": "10.4.5",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
 			"dev": true,
 			"dependencies": {
 				"foreground-child": "^3.1.0",
@@ -4190,9 +4185,9 @@
 			"dev": true
 		},
 		"node_modules/readable-stream": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-			"integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
 			"dependencies": {
 				"abort-controller": "^3.0.0",
 				"buffer": "^6.0.3",
@@ -4236,12 +4231,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/regenerator-runtime": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-			"dev": true
 		},
 		"node_modules/regexp.prototype.flags": {
 			"version": "1.5.2",
@@ -4543,13 +4532,13 @@
 			}
 		},
 		"node_modules/sinon": {
-			"version": "19.0.2",
-			"resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.2.tgz",
-			"integrity": "sha512-euuToqM+PjO4UgXeLETsfQiuoyPXlqFezr6YZDFwHR3t4qaX0fZUe1MfPMznTL5f8BWrVS89KduLdMUsxFCO6g==",
+			"version": "19.0.5",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.5.tgz",
+			"integrity": "sha512-r15s9/s+ub/d4bxNXqIUmwp6imVSdTorIRaxoecYjqTVLZ8RuoXr/4EDGwIBo6Waxn7f2gnURX9zuhAfCwaF6Q==",
 			"dev": true,
 			"dependencies": {
 				"@sinonjs/commons": "^3.0.1",
-				"@sinonjs/fake-timers": "^13.0.2",
+				"@sinonjs/fake-timers": "^13.0.5",
 				"@sinonjs/samsam": "^8.0.1",
 				"diff": "^7.0.0",
 				"nise": "^6.1.1",
@@ -4807,17 +4796,17 @@
 			}
 		},
 		"node_modules/tedious": {
-			"version": "19.0.0",
-			"resolved": "https://registry.npmjs.org/tedious/-/tedious-19.0.0.tgz",
-			"integrity": "sha512-nmxNBAT72mMVCIYp0Ts0Zzd5+LBQjoXlqigCrIjSo2OERSi04vr3EHq3qJxv/zgrSkg7si03SoIIfekTAadA7w==",
+			"version": "19.2.0",
+			"resolved": "https://registry.npmjs.org/tedious/-/tedious-19.2.0.tgz",
+			"integrity": "sha512-2dDjX0KP54riDvJPiiIozv0WRS/giJb3/JG2lWpa2dgM0Gha7mLAxbTR3ltPkGzfoS6M3oDnhYnWuzeaZibHuQ==",
 			"dependencies": {
 				"@azure/core-auth": "^1.7.2",
 				"@azure/identity": "^4.2.1",
 				"@azure/keyvault-keys": "^4.4.0",
-				"@js-joda/core": "^5.6.1",
+				"@js-joda/core": "^5.6.5",
 				"@types/node": ">=18",
-				"bl": "^6.0.11",
-				"iconv-lite": "^0.6.3",
+				"bl": "^6.1.4",
+				"iconv-lite": "^0.7.0",
 				"js-md4": "^0.3.2",
 				"native-duplexpair": "^1.0.0",
 				"sprintf-js": "^1.1.3"
@@ -4846,18 +4835,18 @@
 			}
 		},
 		"node_modules/test-exclude/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
 			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/test-exclude/node_modules/glob": {
-			"version": "10.4.5",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
 			"dev": true,
 			"dependencies": {
 				"foreground-child": "^3.1.0",
@@ -5052,9 +5041,9 @@
 			"dev": true
 		},
 		"node_modules/undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+			"version": "7.16.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="
 		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
@@ -5548,13 +5537,10 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.1.tgz",
-			"integrity": "sha512-+BIznRzyqBf+2wCTxcKE3wDjfGeCoVE61KSHGpkzqrLi8qxqFwBeUFyId2cxkTmm55fzDGnm0+yCxaxygrLUnQ==",
-			"dev": true,
-			"requires": {
-				"regenerator-runtime": "^0.14.0"
-			}
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+			"integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+			"dev": true
 		},
 		"@bcoe/v8-coverage": {
 			"version": "1.0.2",
@@ -5711,9 +5697,9 @@
 			}
 		},
 		"@js-joda/core": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.6.2.tgz",
-			"integrity": "sha512-ow4R+7C24xeTjiMTTZ4k6lvxj7MRBqvqLCQjThQff3RjOmIMokMP20LNYVFhGafJtUx/Xo2Qp4qU8eNoTVH0SA=="
+			"version": "5.6.5",
+			"resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.6.5.tgz",
+			"integrity": "sha512-3zwefSMwHpu8iVUW8YYz227sIv6UFqO31p1Bf1ZH/Vom7CmNyUsXjDBlnNzcuhmOL1XfxZ3nvND42kR23XlbcQ=="
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -5798,27 +5784,19 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "20.12.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.2.tgz",
-			"integrity": "sha512-zQ0NYO87hyN6Xrclcqp7f8ZbXNbRfoGWNcMvHTPQp9UUrwI0mI7XBz+cu7/W6/VClYo2g63B0cjull/srU7LgQ==",
+			"version": "25.0.9",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.9.tgz",
+			"integrity": "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==",
 			"requires": {
-				"undici-types": "~5.26.4"
+				"undici-types": "~7.16.0"
 			}
 		},
 		"@types/readable-stream": {
-			"version": "4.0.11",
-			"resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.11.tgz",
-			"integrity": "sha512-R3eUMUTTKoIoaz7UpYLxvZCrOmCRPRbAmoDDHKcimTEySltaJhF8hLzj4+EzyDifiX5eK6oDQGSfmNnXjxZzYQ==",
+			"version": "4.0.23",
+			"resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.23.tgz",
+			"integrity": "sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==",
 			"requires": {
-				"@types/node": "*",
-				"safe-buffer": "~5.1.1"
-			},
-			"dependencies": {
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-				}
+				"@types/node": "*"
 			}
 		},
 		"@ungap/structured-clone": {
@@ -6079,9 +6057,9 @@
 			"dev": true
 		},
 		"bl": {
-			"version": "6.0.12",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-6.0.12.tgz",
-			"integrity": "sha512-EnEYHilP93oaOa2MnmNEjAcovPS3JlQZOyzGXi3EyEpPhm9qWvdDp7BmAVEVusGzp8LlwQK56Av+OkDoRjzE0w==",
+			"version": "6.1.6",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-6.1.6.tgz",
+			"integrity": "sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg==",
 			"requires": {
 				"@types/readable-stream": "^4.0.0",
 				"buffer": "^6.0.3",
@@ -6090,9 +6068,9 @@
 			}
 		},
 		"brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
@@ -6100,12 +6078,12 @@
 			}
 		},
 		"braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
 			"requires": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			}
 		},
 		"browser-stdout": {
@@ -6376,9 +6354,9 @@
 			"dev": true
 		},
 		"diff": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-			"integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+			"integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
 			"dev": true
 		},
 		"dirty-chai": {
@@ -6872,9 +6850,9 @@
 			}
 		},
 		"fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
 			"requires": {
 				"to-regex-range": "^5.0.1"
@@ -7154,9 +7132,9 @@
 			"dev": true
 		},
 		"iconv-lite": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			}
@@ -7597,9 +7575,9 @@
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 			"dev": true,
 			"requires": {
 				"argparse": "^2.0.1"
@@ -7635,21 +7613,21 @@
 			},
 			"dependencies": {
 				"jwa": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-					"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+					"version": "1.4.2",
+					"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+					"integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
 					"requires": {
-						"buffer-equal-constant-time": "1.0.1",
+						"buffer-equal-constant-time": "^1.0.1",
 						"ecdsa-sig-formatter": "1.0.11",
 						"safe-buffer": "^5.0.1"
 					}
 				},
 				"jws": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-					"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+					"integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
 					"requires": {
-						"jwa": "^1.4.1",
+						"jwa": "^1.4.2",
 						"safe-buffer": "^5.0.1"
 					}
 				},
@@ -7679,21 +7657,21 @@
 			"dev": true
 		},
 		"jwa": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-			"integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
 			"requires": {
-				"buffer-equal-constant-time": "1.0.1",
+				"buffer-equal-constant-time": "^1.0.1",
 				"ecdsa-sig-formatter": "1.0.11",
 				"safe-buffer": "^5.0.1"
 			}
 		},
 		"jws": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-			"integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
 			"requires": {
-				"jwa": "^2.0.0",
+				"jwa": "^2.0.1",
 				"safe-buffer": "^5.0.1"
 			}
 		},
@@ -7917,9 +7895,9 @@
 			},
 			"dependencies": {
 				"brace-expansion": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-					"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+					"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
 					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0"
@@ -7932,9 +7910,9 @@
 					"dev": true
 				},
 				"glob": {
-					"version": "10.4.5",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-					"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+					"version": "10.5.0",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+					"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
 					"dev": true,
 					"requires": {
 						"foreground-child": "^3.1.0",
@@ -8362,9 +8340,9 @@
 			"dev": true
 		},
 		"readable-stream": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-			"integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
 			"requires": {
 				"abort-controller": "^3.0.0",
 				"buffer": "^6.0.3",
@@ -8396,12 +8374,6 @@
 				"globalthis": "^1.0.3",
 				"which-builtin-type": "^1.1.3"
 			}
-		},
-		"regenerator-runtime": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-			"dev": true
 		},
 		"regexp.prototype.flags": {
 			"version": "1.5.2",
@@ -8595,13 +8567,13 @@
 			}
 		},
 		"sinon": {
-			"version": "19.0.2",
-			"resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.2.tgz",
-			"integrity": "sha512-euuToqM+PjO4UgXeLETsfQiuoyPXlqFezr6YZDFwHR3t4qaX0fZUe1MfPMznTL5f8BWrVS89KduLdMUsxFCO6g==",
+			"version": "19.0.5",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.5.tgz",
+			"integrity": "sha512-r15s9/s+ub/d4bxNXqIUmwp6imVSdTorIRaxoecYjqTVLZ8RuoXr/4EDGwIBo6Waxn7f2gnURX9zuhAfCwaF6Q==",
 			"dev": true,
 			"requires": {
 				"@sinonjs/commons": "^3.0.1",
-				"@sinonjs/fake-timers": "^13.0.2",
+				"@sinonjs/fake-timers": "^13.0.5",
 				"@sinonjs/samsam": "^8.0.1",
 				"diff": "^7.0.0",
 				"nise": "^6.1.1",
@@ -8789,17 +8761,17 @@
 			"dev": true
 		},
 		"tedious": {
-			"version": "19.0.0",
-			"resolved": "https://registry.npmjs.org/tedious/-/tedious-19.0.0.tgz",
-			"integrity": "sha512-nmxNBAT72mMVCIYp0Ts0Zzd5+LBQjoXlqigCrIjSo2OERSi04vr3EHq3qJxv/zgrSkg7si03SoIIfekTAadA7w==",
+			"version": "19.2.0",
+			"resolved": "https://registry.npmjs.org/tedious/-/tedious-19.2.0.tgz",
+			"integrity": "sha512-2dDjX0KP54riDvJPiiIozv0WRS/giJb3/JG2lWpa2dgM0Gha7mLAxbTR3ltPkGzfoS6M3oDnhYnWuzeaZibHuQ==",
 			"requires": {
 				"@azure/core-auth": "^1.7.2",
 				"@azure/identity": "^4.2.1",
 				"@azure/keyvault-keys": "^4.4.0",
-				"@js-joda/core": "^5.6.1",
+				"@js-joda/core": "^5.6.5",
 				"@types/node": ">=18",
-				"bl": "^6.0.11",
-				"iconv-lite": "^0.6.3",
+				"bl": "^6.1.4",
+				"iconv-lite": "^0.7.0",
 				"js-md4": "^0.3.2",
 				"native-duplexpair": "^1.0.0",
 				"sprintf-js": "^1.1.3"
@@ -8824,18 +8796,18 @@
 			},
 			"dependencies": {
 				"brace-expansion": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-					"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+					"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
 					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0"
 					}
 				},
 				"glob": {
-					"version": "10.4.5",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-					"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+					"version": "10.5.0",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+					"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
 					"dev": true,
 					"requires": {
 						"foreground-child": "^3.1.0",
@@ -8978,9 +8950,9 @@
 			"dev": true
 		},
 		"undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+			"version": "7.16.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="
 		},
 		"uri-js": {
 			"version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 	"dependencies": {
 		"big-integer": "^1.6.52",
 		"machina": "^4.0.2",
-		"tedious": "^19.0.0"
+		"tedious": "^19.2.0"
 	},
 	"devDependencies": {
 		"c8": "^10.1.3",


### PR DESCRIPTION
Addressing Mend issues:
1. Update tedious to 19.2.0
2. `npm audit fix jws` to update jws to 4.0.1

Link with core-card-service and run coverage tests